### PR TITLE
엔드포인트 scaleMetricCode 값 업데이트

### DIFF
--- a/en/sdk-guide.md
+++ b/en/sdk-guide.md
@@ -397,7 +397,7 @@ When creating an endpoint, the default stage is created.
 | endpoint_model_resource_list[0].resourceOptionDetail.cpu    | Double   | Required    | None          | 0.0~                             | CPU to be used for stage resource                       |
 | endpoint_model_resource_list[0].resourceOptionDetail.memory | Object   | Required    | None          | 1Mi~                             | Memory to be used for stage resource                    |
 | endpoint_model_resource_list[0].podAutoScaleEnable          | Boolean  | Optional    | False         | True, False                      | Pod autoscaler to be used for stage resource            |
-| endpoint_model_resource_list[0].scaleMetricCode             | String   | Optional    | None          | CONCURRENCY, REQUESTS_PER_SECOND | Scaling unit to be used for stage resource              |
+| endpoint_model_resource_list[0].scaleMetricCode             | String   | Optional    | None          | CPU_UTILIZATION, MEMORY_UTILIZATION | Scaling unit to be used for stage resource              |
 | endpoint_model_resource_list[0].scaleMetricTarget           | Integer  | Optional    | None          | 1~                               | Scaling threshold to be used for stage resource         |
 | endpoint_model_resource_list[0].description                 | String   | Optional    | None          | Up to 255 characters             | Description of stage resource                           |
 | tag_list                                                    | Array   | Optional    | None          | Max 10                           | Tag information                                         |
@@ -453,7 +453,7 @@ You can add a new stage to existing endpoints.
 | endpoint_model_resource_list[0].resourceOptionDetail.cpu    | Double   | Required    | None          | 0.0~                             | CPU to be used for stage resource                |
 | endpoint_model_resource_list[0].resourceOptionDetail.memory | Object   | Required    | None          | 1Mi~                             | Memory to be used for stage resource             |
 | endpoint_model_resource_list[0].podAutoScaleEnable          | Boolean  | Optional    | False         | True, False                      | Pod autoscaler to be used for stage resource      |
-| endpoint_model_resource_list[0].scaleMetricCode             | String   | Optional    | None          | CONCURRENCY, REQUESTS_PER_SECOND | Scaling unit to be used for stage resource          |
+| endpoint_model_resource_list[0].scaleMetricCode             | String   | Optional    | None          | CPU_UTILIZATION, MEMORY_UTILIZATION | Scaling unit to be used for stage resource          |
 | endpoint_model_resource_list[0].scaleMetricTarget           | Integer  | Optional    | None          | 1~                               | Scaling threshold to be used for stage resource     |
 | endpoint_model_resource_list[0].description                 | String   | Optional    | None          | Up to 255 characters             | Description of stage resource                                       |
 | tag_list                                                    | Array   | Optional    | None          | Max 10                           | Tag information                                                              |

--- a/ja/sdk-guide.md
+++ b/ja/sdk-guide.md
@@ -397,7 +397,7 @@ easymaker.Model(model_id).delete()
 | endpoint_model_resource_list[0].resourceOptionDetail.cpu    | Double   | 必須  | なし  | 0.0~                             | ステージリソースに使用されるCPU                |
 | endpoint_model_resource_list[0].resourceOptionDetail.memory | Object   | 必須  | なし  | 1Mi~                             | ステージリソースに使用されるメモリ           |
 | endpoint_model_resource_list[0].podAutoScaleEnable          | Boolean  | 選択  | False   | True, False                      | ステージリソースに使用されるPodオートスケーラー |
-| endpoint_model_resource_list[0].scaleMetricCode             | String   | 選択  | なし  | CONCURRENCY, REQUESTS_PER_SECOND | ステージリソースに使用される増設単位        |
+| endpoint_model_resource_list[0].scaleMetricCode             | String   | 選択  | なし  | CPU_UTILIZATION, MEMORY_UTILIZATION | ステージリソースに使用される増設単位        |
 | endpoint_model_resource_list[0].scaleMetricTarget           | Integer  | 選択  | なし  | 1~                               | ステージリソースに使用される増設しきい値   |
 | endpoint_model_resource_list[0].description                 | String   | 選択  | なし  | 最大255文字                | ステージリソースの説明                                     |
 | tag_list                                                    | Array   | 選択  | なし  | 最大10個                   | タグ情報                                                                |
@@ -446,7 +446,7 @@ endpoint = easymaker.Endpoint().create(
 | endpoint_model_resource_list[0].resourceOptionDetail.cpu    | Double   | 必須  | なし  | 0.0~                             | ステージリソースに使用されるCPU                |
 | endpoint_model_resource_list[0].resourceOptionDetail.memory | Object   | 必須  | なし  | 1Mi~                             | ステージリソースに使用されるメモリ           |
 | endpoint_model_resource_list[0].podAutoScaleEnable          | Boolean  | 選択  | False   | True, False                      | ステージリソースに使用されるPodオートスケーラー |
-| endpoint_model_resource_list[0].scaleMetricCode             | String   | 選択  | なし  | CONCURRENCY, REQUESTS_PER_SECOND | ステージリソースに使用される増設単位        |
+| endpoint_model_resource_list[0].scaleMetricCode             | String   | 選択  | なし  | CPU_UTILIZATION, MEMORY_UTILIZATION | ステージリソースに使用される増設単位        |
 | endpoint_model_resource_list[0].scaleMetricTarget           | Integer  | 選択  | なし  | 1~                               | ステージリソースに使用される増設しきい値   |
 | endpoint_model_resource_list[0].description                 | String   | 選択  | なし  | 最大255文字                | ステージリソースの説明                                     |
 | tag_list                                                    | Array   | 選択  | なし  | 最大10個                   | タグ情報                                                            |

--- a/ko/sdk-guide.md
+++ b/ko/sdk-guide.md
@@ -397,7 +397,7 @@ easymaker.Model(model_id).delete()
 | endpoint_model_resource_list[0].resourceOptionDetail.cpu    | Double   | 필수    | 없음    | 0.0~                             | 스테이지 리소스에 사용될 CPU                |
 | endpoint_model_resource_list[0].resourceOptionDetail.memory | Object   | 필수    | 없음    | 1Mi~                             | 스테이지 리소스에 사용될 메모리             |
 | endpoint_model_resource_list[0].podAutoScaleEnable          | Boolean  | 선택    | False   | True, False                      | 스테이지 리소스에 사용될 파드 오토 스케일러 |
-| endpoint_model_resource_list[0].scaleMetricCode             | String   | 선택    | 없음    | CONCURRENCY, REQUESTS_PER_SECOND | 스테이지 리소스에 사용될 증설 단위          |
+| endpoint_model_resource_list[0].scaleMetricCode             | String   | 선택    | 없음    | CPU_UTILIZATION, MEMORY_UTILIZATION | 스테이지 리소스에 사용될 증설 단위          |
 | endpoint_model_resource_list[0].scaleMetricTarget           | Integer  | 선택    | 없음    | 1~                               | 스테이지 리소스에 사용될 증설 임계치 값     |
 | endpoint_model_resource_list[0].description                 | String   | 선택    | 없음    | 최대 255자                  | 스테이지 리소스에 대한 설명                                       |
 | tag_list                                                    | Array   | 선택    | 없음    | 최대 10개                     | 태그 정보                                                                  |
@@ -446,7 +446,7 @@ endpoint = easymaker.Endpoint().create(
 | endpoint_model_resource_list[0].resourceOptionDetail.cpu    | Double   | 필수    | 없음    | 0.0~                             | 스테이지 리소스에 사용될 CPU                |
 | endpoint_model_resource_list[0].resourceOptionDetail.memory | Object   | 필수    | 없음    | 1Mi~                             | 스테이지 리소스에 사용될 메모리             |
 | endpoint_model_resource_list[0].podAutoScaleEnable          | Boolean  | 선택    | False   | True, False                      | 스테이지 리소스에 사용될 파드 오토 스케일러 |
-| endpoint_model_resource_list[0].scaleMetricCode             | String   | 선택    | 없음    | CONCURRENCY, REQUESTS_PER_SECOND | 스테이지 리소스에 사용될 증설 단위          |
+| endpoint_model_resource_list[0].scaleMetricCode             | String   | 선택    | 없음    | CPU_UTILIZATION, MEMORY_UTILIZATION | 스테이지 리소스에 사용될 증설 단위          |
 | endpoint_model_resource_list[0].scaleMetricTarget           | Integer  | 선택    | 없음    | 1~                               | 스테이지 리소스에 사용될 증설 임계치 값     |
 | endpoint_model_resource_list[0].description                 | String   | 선택    | 없음    | 최대 255자                  | 스테이지 리소스에 대한 설명                                       |
 | tag_list                                                    | Array   | 선택    | 없음    | 최대 10개                     | 태그 정보                                                              |

--- a/zh/sdk-guide.md
+++ b/zh/sdk-guide.md
@@ -397,7 +397,7 @@ When creating an endpoint, the default stage is created.
 | endpoint_model_resource_list[0].resourceOptionDetail.cpu    | Double   | Required    | None          | 0.0~                             | CPU to be used for stage resource                       |
 | endpoint_model_resource_list[0].resourceOptionDetail.memory | Object   | Required    | None          | 1Mi~                             | Memory to be used for stage resource                    |
 | endpoint_model_resource_list[0].podAutoScaleEnable          | Boolean  | Optional    | False         | True, False                      | Pod autoscaler to be used for stage resource            |
-| endpoint_model_resource_list[0].scaleMetricCode             | String   | Optional    | None          | CONCURRENCY, REQUESTS_PER_SECOND | Scaling unit to be used for stage resource              |
+| endpoint_model_resource_list[0].scaleMetricCode             | String   | Optional    | None          | CPU_UTILIZATION, MEMORY_UTILIZATION | Scaling unit to be used for stage resource              |
 | endpoint_model_resource_list[0].scaleMetricTarget           | Integer  | Optional    | None          | 1~                               | Scaling threshold to be used for stage resource         |
 | endpoint_model_resource_list[0].description                 | String   | Optional    | None          | Up to 255 characters             | Description of stage resource                           |
 | tag_list                                                    | Array   | Optional    | None          | Max 10                           | Tag information                                         |
@@ -453,7 +453,7 @@ You can add a new stage to existing endpoints.
 | endpoint_model_resource_list[0].resourceOptionDetail.cpu    | Double   | Required    | None          | 0.0~                             | CPU to be used for stage resource                |
 | endpoint_model_resource_list[0].resourceOptionDetail.memory | Object   | Required    | None          | 1Mi~                             | Memory to be used for stage resource             |
 | endpoint_model_resource_list[0].podAutoScaleEnable          | Boolean  | Optional    | False         | True, False                      | Pod autoscaler to be used for stage resource      |
-| endpoint_model_resource_list[0].scaleMetricCode             | String   | Optional    | None          | CONCURRENCY, REQUESTS_PER_SECOND | Scaling unit to be used for stage resource          |
+| endpoint_model_resource_list[0].scaleMetricCode             | String   | Optional    | None          | CPU_UTILIZATION, MEMORY_UTILIZATION | Scaling unit to be used for stage resource          |
 | endpoint_model_resource_list[0].scaleMetricTarget           | Integer  | Optional    | None          | 1~                               | Scaling threshold to be used for stage resource     |
 | endpoint_model_resource_list[0].description                 | String   | Optional    | None          | Up to 255 characters             | Description of stage resource                                       |
 | tag_list                                                    | Array   | Optional    | None          | Max 10                           | Tag information                                                              |


### PR DESCRIPTION
엔드포인트 작업중 scaleMetricCode값이 API에선 변경된거 같은데 가이드엔 업데이트가 안되어있는거 같아서 수정합니다