### PR TITLE
모델 포맷 코드 가이드를 modelFormatCode 신 체계로 갱신

### DIFF
--- a/en/sdk-guide.md
+++ b/en/sdk-guide.md
@@ -380,7 +380,7 @@ The model is used when creating endpoints.
 
 | Name                       | Type     | Required                              | Default value | Valid range   | Description                                  |
 |--------------------------|--------|------------------------------------|-----|---------|-------------------------------------|
-| model_format_code       | easymaker.ModelFormatCode | Required                                 | None  | TENSORFLOW, PYTORCH, SCIKIT_LEARN, HUGGING_FACE, TENSORFLOW_TRITON, PYTORCH_TRITON, ONNX_TRITON | Model format information |
+| model_format_code | easymaker.ModelFormatCode | Required | None | TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON | Model format information used for inference serving |
 | training_id              | String | Required if hyperparameter_tuning_id does not exist | None  | None      | Training ID to create a model                       |
 | hyperparameter_tuning_id | String | Required if training_id is not present              | None  | None      | Hyperparameter tuning ID to be created by model (created by best learning) |
 | model_name               | String | Required                                 | None  | Up to 50 characters  | Model name                               |
@@ -404,7 +404,7 @@ Even if there is no training ID, you can create a model by entering the path inf
 
 | Name                   | Type     | Required | Default value | Valid range                                   | Description                                                  |
 |----------------------|--------|-------|-----|-----------------------------------------|-----------------------------------------------------|
-| model_format_code       | easymaker.ModelFormatCode   | Required    | None  | easymaker.ModelFormatCode.TENSORFLOW, easymaker.ModelFormatCode.PYTORCH, easymaker.ModelFormatCode.SCIKIT_LEARN, easymaker.ModelFormatCode.HUGGING_FACE, easymaker.ModelFormatCode.TENSORFLOW_TRITON, easymaker.ModelFormatCode.PYTORCH_TRITON, easymaker.ModelFormatCode.ONNX_TRITON | Model format information used for inference serving                                    |
+| model_format_code | easymaker.ModelFormatCode | Required | None | TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON | Model format information used for inference serving |
 | model_upload_uri            | String | Required    | None  | Up to 255 characters                                 | Path for model file (NHN Cloud Object Storage or NHN Cloud NAS) |
 | model_name           | String | Required    | None  | Up to 50 characters                                  | Model name                                               |
 | description    | String | Optional    | None  | Up to 255 characters                                 | Description for model                                           |

--- a/ja/sdk-guide.md
+++ b/ja/sdk-guide.md
@@ -379,7 +379,7 @@ easymaker.HyperparameterTuning(hyperparameter_tuning_id).delete()
 
 | 名前                      | タイプ    | 必須かどうか                             | デフォルト値 | 有効範囲  | 説明                                 |
 |--------------------------|--------|------------------------------------|-----|---------|-------------------------------------|
-| model_format_code       | easymaker.ModelFormatCode | 必須                                | なし  | TENSORFLOW, PYTORCH, SCIKIT_LEARN, HUGGING_FACE, TENSORFLOW_TRITON, PYTORCH_TRITON, ONNX_TRITON | モデルフォーマット情報 |
+| model_format_code | easymaker.ModelFormatCode | 必須 | なし | TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON | 推論サービングに使用されるモデルフォーマット情報 |
 | training_id              | String | hyperparameter_tuning_idがない場合は必須 | なし  | なし      | モデルとして作成する学習ID                       |
 | hyperparameter_tuning_id | String | training_idがない場合は必須             | なし  | なし      | モデルとして作成するハイパーパラメータチューニングID(最高学習で作成済み) |
 | model_name               | String | 必須                                | なし  | 最大50文字 | モデル名                              |
@@ -403,7 +403,7 @@ model = easymaker.Model().create(
 
 | 名前               | タイプ | 必須かどうか | デフォルト値 | 有効範囲                                      | 説明                                              |
 |----------------------|--------|-------|-----|-------------------------------------------|-----------------------------------------------------|
-| model_format_code       | easymaker.ModelFormatCode   | 必須 | なし | easymaker.ModelFormatCode.TENSORFLOW, easymaker.ModelFormatCode.PYTORCH, easymaker.ModelFormatCode.SCIKIT_LEARN, easymaker.ModelFormatCode.HUGGING_FACE, easymaker.ModelFormatCode.TENSORFLOW_TRITON, easymaker.ModelFormatCode.PYTORCH_TRITON, easymaker.ModelFormatCode.ONNX_TRITON | 推論サービングに使用されるモデルフォーマット情報                                |
+| model_format_code | easymaker.ModelFormatCode | 必須 | なし | TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON | 推論サービングに使用されるモデルフォーマット情報 |
 | model_upload_uri            | String | 必須 | なし | 最大255文字                                   | モデルファイルパス(NHN Cloud Object StorageまたはNHN Cloud NAS) |
 | model_name           | String | 必須 | なし | 最大50文字                                    | モデル名                                           |
 | description    | String | 任意 | なし | 最大255文字                                   | モデルの説明                                       |

--- a/ko/console-guide-gov.md
+++ b/ko/console-guide-gov.md
@@ -682,7 +682,8 @@ AI EasyMaker의 학습 결과의 모델 또는 외부의 모델을 아티팩트�
     그 외의 파일 형식은 지원하지 않습니다.
 
 !!! danger "주의"
-    TensorFlow (Triton), PyTorch (Triton), ONNX (Triton) 모델을 생성하는 경우, 입력하는 모델 아티팩트 경로에 Triton으로 모델을 실행할 수 있는 구조로 모델 파일과 `config.pbtxt` 파일이 저장되어 있어야 합니다.
+    Triton 모델은 TensorFlow, PyTorch, ONNX 백엔드만 지원합니다.
+    Triton 모델을 생성하는 경우, 입력하는 모델 아티팩트 경로에 Triton으로 모델을 실행할 수 있는 구조로 모델 파일과 `config.pbtxt` 파일이 저장되어 있어야 합니다.
     아래의 예시를 참고하세요.
     <details>
     <summary><strong>예시</strong></summary>

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -682,7 +682,8 @@ AI EasyMaker의 학습 결과의 모델 또는 외부의 모델을 아티팩트�
     그 외의 파일 형식은 지원하지 않습니다.
 
 !!! danger "주의"
-    TensorFlow (Triton), PyTorch (Triton), ONNX (Triton) 모델을 생성하는 경우, 입력하는 모델 아티팩트 경로에 Triton으로 모델을 실행할 수 있는 구조로 모델 파일과 `config.pbtxt` 파일이 저장되어 있어야 합니다.
+    Triton 모델은 TensorFlow, PyTorch, ONNX 백엔드만 지원합니다.
+    Triton 모델을 생성하는 경우, 입력하는 모델 아티팩트 경로에 Triton으로 모델을 실행할 수 있는 구조로 모델 파일과 `config.pbtxt` 파일이 저장되어 있어야 합니다.
     아래의 예시를 참고하세요.
     <details>
     <summary><strong>예시</strong></summary>

--- a/ko/sdk-guide-gov.md
+++ b/ko/sdk-guide-gov.md
@@ -381,7 +381,7 @@ easymaker.HyperparameterTuning(hyperparameter_tuning_id).delete()
 
 | 이름                       | 타입     | 필수 여부                              | 기본값 | 유효 범위   | 설명                                  |
 |--------------------------|--------|------------------------------------|-----|---------|-------------------------------------|
-| model_format_code       | easymaker.ModelFormatCode | 필수                                 | 없음  | TENSORFLOW, PYTORCH, SCIKIT_LEARN, HUGGING_FACE, TENSORFLOW_TRITON, PYTORCH_TRITON, ONNX_TRITON | 모델 포맷 정보 |
+| model_format_code | easymaker.ModelFormatCode | 필수 | 없음 | TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON | 추론 서빙에 사용되는 모델 포맷 정보 |
 | training_id              | String | hyperparameter_tuning_id가 없는 경우 필수 | 없음  | 없음      | 모델로 생성할 학습 ID                       |
 | hyperparameter_tuning_id | String | training_id가 없는 경우 필수              | 없음  | 없음      | 모델로 생성할 하이퍼파라미터 튜닝 ID(최고 학습으로 생성됨) |
 | model_name               | String | 필수                                 | 없음  | 최대 50자  | 모델 이름                               |
@@ -405,7 +405,7 @@ model = easymaker.Model().create(
 
 | 이름                   | 타입     | 필수 여부 | 기본값 | 유효 범위                                   | 설명                                                  |
 |----------------------|--------|-------|-----|-----------------------------------------|-----------------------------------------------------|
-| model_format_code       | easymaker.ModelFormatCode   | 필수    | 없음  | easymaker.ModelFormatCode.TENSORFLOW, easymaker.ModelFormatCode.PYTORCH, easymaker.ModelFormatCode.SCIKIT_LEARN, easymaker.ModelFormatCode.HUGGING_FACE, easymaker.ModelFormatCode.TENSORFLOW_TRITON, easymaker.ModelFormatCode.PYTORCH_TRITON, easymaker.ModelFormatCode.ONNX_TRITON | 추론 서빙에 사용되는 모델 포맷 정보                                    |
+| model_format_code | easymaker.ModelFormatCode | 필수 | 없음 | TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON | 추론 서빙에 사용되는 모델 포맷 정보 |
 | model_upload_uri            | String | 필수    | 없음  | 최대 255자                                 | 모델 파일 경로(NHN Cloud Object Storage 또는 NHN Cloud NAS) |
 | model_name           | String | 필수    | 없음  | 최대 50자                                  | 모델 이름                                               |
 | description    | String | 선택    | 없음  | 최대 255자                                 | 모델에 대한 설명                                           |

--- a/ko/sdk-guide.md
+++ b/ko/sdk-guide.md
@@ -380,7 +380,7 @@ easymaker.HyperparameterTuning(hyperparameter_tuning_id).delete()
 
 | 이름                       | 타입     | 필수 여부                              | 기본값 | 유효 범위   | 설명                                  |
 |--------------------------|--------|------------------------------------|-----|---------|-------------------------------------|
-| model_format_code       | easymaker.ModelFormatCode | 필수                                 | 없음  | TENSORFLOW, PYTORCH, SCIKIT_LEARN, HUGGING_FACE, TENSORFLOW_TRITON, PYTORCH_TRITON, ONNX_TRITON | 모델 포맷 정보 |
+| model_format_code | easymaker.ModelFormatCode | 필수 | 없음 | TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON | 추론 서빙에 사용되는 모델 포맷 정보 |
 | training_id              | String | hyperparameter_tuning_id가 없는 경우 필수 | 없음  | 없음      | 모델로 생성할 학습 ID                       |
 | hyperparameter_tuning_id | String | training_id가 없는 경우 필수              | 없음  | 없음      | 모델로 생성할 하이퍼파라미터 튜닝 ID(최고 학습으로 생성됨) |
 | model_name               | String | 필수                                 | 없음  | 최대 50자  | 모델 이름                               |
@@ -404,7 +404,7 @@ model = easymaker.Model().create(
 
 | 이름                   | 타입     | 필수 여부 | 기본값 | 유효 범위                                   | 설명                                                  |
 |----------------------|--------|-------|-----|-----------------------------------------|-----------------------------------------------------|
-| model_format_code       | easymaker.ModelFormatCode   | 필수    | 없음  | easymaker.ModelFormatCode.TENSORFLOW, easymaker.ModelFormatCode.PYTORCH, easymaker.ModelFormatCode.SCIKIT_LEARN, easymaker.ModelFormatCode.HUGGING_FACE, easymaker.ModelFormatCode.TENSORFLOW_TRITON, easymaker.ModelFormatCode.PYTORCH_TRITON, easymaker.ModelFormatCode.ONNX_TRITON | 추론 서빙에 사용되는 모델 포맷 정보                                    |
+| model_format_code | easymaker.ModelFormatCode | 필수 | 없음 | TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON | 추론 서빙에 사용되는 모델 포맷 정보 |
 | model_upload_uri            | String | 필수    | 없음  | 최대 255자                                 | 모델 파일 경로(NHN Cloud Object Storage 또는 NHN Cloud NAS) |
 | model_name           | String | 필수    | 없음  | 최대 50자                                  | 모델 이름                                               |
 | description    | String | 선택    | 없음  | 최대 255자                                 | 모델에 대한 설명                                           |


### PR DESCRIPTION
- SDK 가이드: 모델 생성 model_format_code 유효값을 신 ModelFormatCode 6종 (TENSORFLOW, PYTORCH, SKLEARN, HUGGING_FACE, TRITON, SAPEON)으로 정정하고, 두 모델 생성 표의 행을 동일하게 통일 (ko/gov/en/ja)
- 콘솔 가이드: Triton 주의 블록을 단일 Triton 포맷 기준으로 갱신하고, 지원 백엔드(TensorFlow, PyTorch, ONNX)를 먼저 명시 (ko/gov)